### PR TITLE
Add component recognition support

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -15,7 +15,7 @@ export default (editor: Editor, { blockCustomCode }: PluginOptions = {}) => {
     category: 'Extra',
     activate: true,
     select: true,
-    content: { type: typeCustomCode },
+    content: { type: typeCustomCode, attributes: { class: 'grapes-custom-code' } },
     ...blockCustomCode
   });
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -18,6 +18,7 @@ export default (editor: Editor, opts: PluginOptions = {}) => {
   });
 
   Components.addType(typeCustomCode, {
+    isComponent: el => el.className === 'grapes-custom-code',
     model: {
       defaults: {
         name: 'Custom Code',


### PR DESCRIPTION
This change allows the final HTML that is output from the editors using this plugin, to then consume/import/open said HTML content again and recognise the custom-code blocks that you previously added. This has been important for my project due to limitation preventing me from running the editor off of the Component JSON Data.

Please consider merging this in so that I can switch back to your awesome project rather than my Fork. :-)